### PR TITLE
Rearrange dependencies to prevent warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,21 +16,12 @@
   "author": "Vox Product",
   "license": "UNLICENSED",
   "dependencies": {
+    "eslint": "^3.19.0",
     "eslint-plugin-html": "^1.7.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-promise": "^3.4.0"
-  },
-  "peerDependencies": {
-    "eslint": ">= 3",
-    "eslint-plugin-html": "^1.7.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-promise": "^3.4.0"
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-promise": "^3.6.0"
   },
   "devDependencies": {
-    "eslint": "^3.11.1",
-    "eslint-find-rules": "^1.14.3",
-    "eslint-plugin-html": "^1.7.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-promise": "^3.4.0"
+    "eslint-find-rules": "^1.14.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-voxproduct",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared eslint config for Vox Product",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In the Tower and content-api repos, we were getting yarn warnings from the arrangement of dependencies in this package.json. This rearranges them a little!