### PR TITLE
Add no-restricted-syntax rule to ecosystem config

### DIFF
--- a/ecosystem.js
+++ b/ecosystem.js
@@ -1,6 +1,17 @@
 module.exports = {
   extends: ['voxproduct'],
   rules: {
-    'no-foreach/no-foreach': 2
+    'no-foreach/no-foreach': 'error',
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForStatement',
+        message: 'for (let [index, item] of array.entries()) is preferred where possible'
+      },
+      {
+        selector: 'ForInStatement',
+        message: 'for (let key of Object.keys(obj)) is preferred where possible'
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-voxproduct",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Shared eslint config for Vox Product",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Following up on #5, this uses the `no-restricted-syntax` rule to disallow `for(let i = 0; i < array.length; i++)` and `for (let key in obj)`, with custom messages indicating a preference for `for...of` loops instead.